### PR TITLE
Feature/question card gui

### DIFF
--- a/UIButton+.swift
+++ b/UIButton+.swift
@@ -1,0 +1,29 @@
+//
+//  UIButton+.swift
+//  Yetda_iOS
+//
+//  Created by 임수현 on 2020/02/02.
+//  Copyright © 2020 Yetda. All rights reserved.
+//
+
+import UIKit
+
+extension UIButton {
+    
+    func setYesNoButton(isYesBtn: Bool) {
+        
+        if isYesBtn {
+            self.setTitle("O", for: .normal)
+            self.setTitleColor(UIColor.pastelRed, for: .normal)
+        } else {
+            self.setTitle("X", for: .normal)
+            self.setTitleColor(UIColor.blueGrey, for: .normal)
+        }
+        
+        self.titleLabel?.font = .boldSystemFont(ofSize: 28)
+        self.layer.cornerRadius = 38
+        self.layer.borderColor = UIColor.paleLilac.cgColor
+        self.layer.borderWidth = 2
+    }
+}
+

--- a/UIButton+.swift
+++ b/UIButton+.swift
@@ -25,5 +25,12 @@ extension UIButton {
         self.layer.borderColor = UIColor.paleLilac.cgColor
         self.layer.borderWidth = 2
     }
+    
+    func setUnderLine() {
+        let underlineAttribute = [NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue]
+        let underlineAttributedString = NSAttributedString(string: "StringWithUnderLine", attributes: underlineAttribute)
+        self.titleLabel?.attributedText = underlineAttributedString
+        
+    }
 }
 

--- a/UIColor+.swift
+++ b/UIColor+.swift
@@ -14,4 +14,8 @@ extension UIColor {
     static let paleLilac = UIColor(red: 223/255, green: 223/255, blue: 228/255, alpha: 1)
     static let pastelRed = UIColor(red: 218/255, green: 89/255, blue: 89/255, alpha: 1)
     static let shadowColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.03)
+    
+    static func blueGreyWith(alpha: CGFloat) -> UIColor {
+        return UIColor(red: 140/255, green: 144/255, blue: 152/255, alpha: alpha)
+    }
 }

--- a/UIColor+.swift
+++ b/UIColor+.swift
@@ -9,12 +9,9 @@
 import UIKit
 
 extension UIColor {
-    static let fadedBlue = UIColor(red: 109/255, green: 148/255, blue: 178/255, alpha: 1)
-    static let cloudyBlue = UIColor(red: 188/255, green: 198/255, blue: 206/255, alpha: 1)
-    static let brownGrey = UIColor(red: 149/255, green: 149/255, blue: 149/255, alpha: 1)
+    static let blueGrey = UIColor(red: 140/255, green: 144/255, blue: 152/255, alpha: 1)
     static let brownishGrey = UIColor(red: 102/255, green: 102/255, blue: 102/255, alpha: 1)
     static let paleLilac = UIColor(red: 223/255, green: 223/255, blue: 228/255, alpha: 1)
-    static let charcoalGrey = UIColor(red: 50/255, green: 65/255, blue: 72/255, alpha: 1)
-    
+    static let pastelRed = UIColor(red: 218/255, green: 89/255, blue: 89/255, alpha: 1)
     static let shadowColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.03)
 }

--- a/Yetda_iOS.xcodeproj/project.pbxproj
+++ b/Yetda_iOS.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3A2F483323DDB1EF0034C429 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F483223DDB1EF0034C429 /* UIColor+.swift */; };
 		3A2F483723DDB26A0034C429 /* QuestionViewController+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F483623DDB26A0034C429 /* QuestionViewController+Layout.swift */; };
 		3A2F483923E537010034C429 /* QuestionViewController+ClickMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F483823E537010034C429 /* QuestionViewController+ClickMotion.swift */; };
+		3A2F483B23E6C0380034C429 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F483A23E6C0380034C429 /* UIButton+.swift */; };
 		3AF6A9BE23C4A72400B588CE /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3AF6A9BD23C4A72400B588CE /* .swiftlint.yml */; };
 		3AF6A9C223C4AD0300B588CE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3AF6A9C123C4AD0300B588CE /* GoogleService-Info.plist */; };
 		4C002D7423D0B49E00A1AC91 /* YetdaIntegrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C002D7323D0B49E00A1AC91 /* YetdaIntegrator.swift */; };
@@ -44,6 +45,7 @@
 		3A2F483223DDB1EF0034C429 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = SOURCE_ROOT; };
 		3A2F483623DDB26A0034C429 /* QuestionViewController+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QuestionViewController+Layout.swift"; sourceTree = "<group>"; };
 		3A2F483823E537010034C429 /* QuestionViewController+ClickMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QuestionViewController+ClickMotion.swift"; sourceTree = "<group>"; };
+		3A2F483A23E6C0380034C429 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = SOURCE_ROOT; };
 		3AF6A9BD23C4A72400B588CE /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		3AF6A9C123C4AD0300B588CE /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		4C002D7323D0B49E00A1AC91 /* YetdaIntegrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YetdaIntegrator.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 			children = (
 				3A2F483023DDB1C50034C429 /* UIView+.swift */,
 				3A2F483223DDB1EF0034C429 /* UIColor+.swift */,
+				3A2F483A23E6C0380034C429 /* UIButton+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<unknown>";
@@ -411,6 +414,7 @@
 				FAECF8B723DADF7200B5DF95 /* BirthDayViewController+layout.swift in Sources */,
 				FA36BF6523E27E2F00B9F1F5 /* GenderViewController+UIButton.swift in Sources */,
 				FA85C4C523E1595F0083C550 /* GenderViewController+layout.swift in Sources */,
+				3A2F483B23E6C0380034C429 /* UIButton+.swift in Sources */,
 				FAEC903723CC84A200010233 /* NameViewController.swift in Sources */,
 				3A2F483923E537010034C429 /* QuestionViewController+ClickMotion.swift in Sources */,
 				4C002D7B23D0B9C500A1AC91 /* BaseViewController.swift in Sources */,

--- a/Yetda_iOS/Source/Views/GenderView/GenderViewController+layout.swift
+++ b/Yetda_iOS/Source/Views/GenderView/GenderViewController+layout.swift
@@ -75,7 +75,7 @@ extension GenderViewController {
         view.backgroundColor = .clear
         view.layer.cornerRadius = 13
         view.layer.borderWidth = 1
-        view.layer.borderColor = UIColor.charcoalGrey.cgColor
+        view.layer.borderColor = UIColor.brownishGrey.cgColor
         
         view.snp.makeConstraints { (make) in
             make.width.height.equalTo(26)
@@ -102,10 +102,10 @@ extension GenderViewController {
 
     //     male/female Buttons are mutually exclusive when selecting
     @objc func buttonAction(sender: UIButton!) {
-        if sender.backgroundColor == .charcoalGrey {
+        if sender.backgroundColor == .brownishGrey {
             sender.backgroundColor = .clear
         } else {
-            sender.backgroundColor = .charcoalGrey
+            sender.backgroundColor = .brownishGrey
         }
 
         if sender == maleButton {

--- a/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
+++ b/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
@@ -11,8 +11,16 @@ import SnapKit
 
 extension QuestionViewController {
     
+    /*
+     1. setup self view properties
+     2. setup self view contraints
+     3. add subviews
+     4. setup subviews properties
+    */
+    
     func setupView() {  // 전체 뷰
         
+        // add subviews
         self.view.addSubview(descriptionLabel)
         self.view.addSubview(backCardView)
         self.view.addSubview(frontCardView)
@@ -20,6 +28,7 @@ extension QuestionViewController {
         self.view.addSubview(yesButton)
         self.view.addSubview(midButton)
         
+        // setup subviews properties
         setupNumLabel()
         setupBackCardView()
         setupFrontCardView()
@@ -29,21 +38,25 @@ extension QuestionViewController {
     
     private func setupNumLabel() {
         
+        // setup self view properties
         descriptionLabel.text = "@@님은 어떤 사람인가요?"
         descriptionLabel.font = .systemFont(ofSize: 18)
         descriptionLabel.textColor = UIColor.brownishGrey   
         descriptionLabel.sizeToFit()
         
+        // setup self constraints
         descriptionLabel.snp.makeConstraints { (make) in
             make.centerX.equalTo(self.view)
             make.top.equalTo(self.view).offset(164)
         }
     }
     
-    private func setupBackCardView() {  // 다음 카드 뷰 부분
+    private func setupBackCardView() {  // 뒤에 깔려있는 카드 뷰 부분
         
+        // setup self view properties
         backCardView.setCardView()
         
+        // setup self view contstraints
         backCardView.snp.makeConstraints { (make) in
             make.width.equalTo(cardSize.width)
             make.height.equalTo(cardSize.height)
@@ -53,21 +66,29 @@ extension QuestionViewController {
     
     private func setupFrontCardView() {  // 현재 카드 뷰 부분
     
+        // setup self view properties
         frontCardView.setCardView()
-        frontCardView.addSubview(frontCardLabel)
         
+        // setup self view contraints
         frontCardView.snp.makeConstraints { (make) in
             make.width.equalTo(cardSize.width)
             make.height.equalTo(cardSize.height)
             make.center.equalTo(self.view)
         }
         
+        // add subviews
+        frontCardView.addSubview(frontCardLabel)
+        
+        // setup subviews properties
         setupFrontCardLabel()
     }
     
     private func setupFrontCardLabel() {
+        
+        // setup self view properties
         frontCardLabel.text = "Question\(questionNum)"
         
+        // setup self view contraints
         frontCardLabel.snp.makeConstraints { (make) in
             make.center.equalTo(frontCardView)
         }
@@ -75,29 +96,39 @@ extension QuestionViewController {
     
     private func setupYNButton() {  // 예 아니오 버튼 부분
         
+        // setup self view properties
         noButton.setTitle("X", for: .normal)
-        noButton.setTitleColor(UIColor.cloudyBlue, for: .normal)
+        noButton.setTitleColor(UIColor.blueGrey, for: .normal)
         noButton.titleLabel?.font = .boldSystemFont(ofSize: 28)
+        noButton.layer.cornerRadius = 38
+        noButton.layer.borderColor = UIColor.paleLilac.cgColor
+        noButton.layer.borderWidth = 2
         
         yesButton.setTitle("O", for: .normal)
-        yesButton.setTitleColor(UIColor.cloudyBlue, for: .normal)
+        yesButton.setTitleColor(UIColor.pastelRed, for: .normal)
         yesButton.titleLabel?.font = .boldSystemFont(ofSize: 28)
+        yesButton.layer.cornerRadius = 38
+        yesButton.layer.borderColor = UIColor.paleLilac.cgColor
+        yesButton.layer.borderWidth = 2
         
+        // setup self view contraints
         noButton.snp.makeConstraints { (make) in
-            make.centerY.equalTo(self.view)
-            make.centerX.equalTo(self.view.snp.left).offset((UIScreen.main.bounds.width - cardSize.width)/4)
+            make.width.height.equalTo(76)
+            make.top.equalTo(self.frontCardView.snp.bottom).offset(35)
+            make.right.equalTo(self.view.snp.centerX).offset(-13)
         }
         
         yesButton.snp.makeConstraints { (make) in
-            make.centerY.equalTo(self.view)
-            make.centerX.equalTo(self.view.snp.right).offset(-(UIScreen.main.bounds.width - cardSize.width)/4)
+        make.width.height.equalTo(76)
+            make.top.equalTo(self.frontCardView.snp.bottom).offset(35)
+            make.left.equalTo(self.view.snp.centerX).offset(13)
         }
     }
     
     private func setupMidButton() {
         
         midButton.setTitle("잘 모르겠어요", for: .normal)
-        midButton.setTitleColor(.brownGrey, for: .normal)
+        midButton.setTitleColor(.blueGrey, for: .normal)
         midButton.titleLabel?.font = .systemFont(ofSize: 18)
         
         // 버튼에 밑줄

--- a/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
+++ b/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
@@ -97,19 +97,9 @@ extension QuestionViewController {
     private func setupYNButton() {  // 예 아니오 버튼 부분
         
         // setup self view properties
-        noButton.setTitle("X", for: .normal)
-        noButton.setTitleColor(UIColor.blueGrey, for: .normal)
-        noButton.titleLabel?.font = .boldSystemFont(ofSize: 28)
-        noButton.layer.cornerRadius = 38
-        noButton.layer.borderColor = UIColor.paleLilac.cgColor
-        noButton.layer.borderWidth = 2
+        noButton.setYesNoButton(isYesBtn: false)
+        yesButton.setYesNoButton(isYesBtn: true)
         
-        yesButton.setTitle("O", for: .normal)
-        yesButton.setTitleColor(UIColor.pastelRed, for: .normal)
-        yesButton.titleLabel?.font = .boldSystemFont(ofSize: 28)
-        yesButton.layer.cornerRadius = 38
-        yesButton.layer.borderColor = UIColor.paleLilac.cgColor
-        yesButton.layer.borderWidth = 2
         
         // setup self view contraints
         noButton.snp.makeConstraints { (make) in

--- a/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
+++ b/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
@@ -100,7 +100,6 @@ extension QuestionViewController {
         noButton.setYesNoButton(isYesBtn: false)
         yesButton.setYesNoButton(isYesBtn: true)
         
-        
         // setup self view contraints
         noButton.snp.makeConstraints { (make) in
             make.width.height.equalTo(76)
@@ -117,20 +116,17 @@ extension QuestionViewController {
     
     private func setupMidButton() {
         
+        // setup self view properties
         midButton.setTitle("잘 모르겠어요", for: .normal)
-        midButton.setTitleColor(.blueGrey, for: .normal)
+        midButton.setTitleColor(.blueGreyWith(alpha: 0.35), for: .normal)
         midButton.titleLabel?.font = .systemFont(ofSize: 18)
+        midButton.setUnderLine()
         
-        // 버튼에 밑줄
-        let underlineAttribute = [NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue]
-        let underlineAttributedString = NSAttributedString(string: "StringWithUnderLine", attributes: underlineAttribute)
-        midButton.titleLabel?.attributedText = underlineAttributedString
-        
+        // setup self view contraints
         midButton.snp.makeConstraints { (make) in
-            make.height.equalTo(40)
-            make.width.equalTo(150)
-            make.top.equalTo(frontCardView.snp.bottom).offset(33)
-            make.centerX.equalTo(frontCardView)
+            make.height.equalTo(19)
+            make.top.equalTo(noButton.snp.bottom).offset(36)
+            make.centerX.equalTo(self.view)
         }
     }
 }

--- a/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
+++ b/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
@@ -29,14 +29,14 @@ extension QuestionViewController {
         self.view.addSubview(midButton)
         
         // setup subviews properties
-        setupNumLabel()
+        setupDescriptionLabel()
         setupBackCardView()
         setupFrontCardView()
         setupYNButton()
         setupMidButton()
     }
     
-    private func setupNumLabel() {
+    private func setupDescriptionLabel() {
         
         // setup self view properties
         descriptionLabel.text = "@@님은 어떤 사람인가요?"

--- a/Yetda_iOS/Source/Views/QuestionView/QuestionViewController.swift
+++ b/Yetda_iOS/Source/Views/QuestionView/QuestionViewController.swift
@@ -13,7 +13,7 @@ class QuestionViewController: UIViewController {
     var questionNum = 1
     var basePoint = 5
     
-    let cardSize = CGSize(width: 266, height: 297)
+    let cardSize = CGSize(width: 272, height: 280)
     
     let frontCardView: UIView = UIView()
     let backCardView: UIView = UIView()


### PR DESCRIPTION
resolve: #33 

## TODO (미구현)
* 제플린에 iOS용 GUI 추가되면 디테일 사이즈 조정 필요 
* 뒤로가기 버튼
* 상단의 진행률 프로그래스 바
* OX 버튼 리소스 추가 예정 (현재는 text로 표현되어 있음)
* 카드 뷰 중첩되어 있는 리소스 추가 예정 (코드로 직접 구현할지 or 리소스로 추가할지 논의 필요!)

## DONE
* OX 버튼 위치 변경
* UIButton에 setYesNoButton() 함수 Extend
* 잘 모르겠어요 버튼 위치 변경
* UIButton에 setUnderLine() 함수 Extend

![image](https://user-images.githubusercontent.com/37800715/73605744-9356fb80-45e5-11ea-8069-392e85d3720d.png)

