### PR TITLE
Feature/name view gui

### DIFF
--- a/UIColor+.swift
+++ b/UIColor+.swift
@@ -17,4 +17,6 @@ extension UIColor {
     static let charcoalGrey = UIColor(red: 50/255, green: 65/255, blue: 72/255, alpha: 1)
     
     static let shadowColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.03)
+    
+    static let blueGrey = UIColor(red: 140/255, green: 144/255, blue: 152/255, alpha: 1)
 }

--- a/UIColor+.swift
+++ b/UIColor+.swift
@@ -19,4 +19,7 @@ extension UIColor {
     static let shadowColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.03)
     
     static let blueGrey = UIColor(red: 140/255, green: 144/255, blue: 152/255, alpha: 1)
+    static let pastelRed = UIColor(red: 197/255, green: 74/255, blue: 74/255, alpha: 1)
+    static let veryLightPink = UIColor(red: 201/255, green: 201/255, blue: 201/255, alpha: 1)
+    static let veryLightPink2 = UIColor(red: 238/255, green: 238/255, blue: 238/255, alpha: 1)
 }

--- a/Yetda_iOS.xcodeproj/project.pbxproj
+++ b/Yetda_iOS.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3A2F483323DDB1EF0034C429 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F483223DDB1EF0034C429 /* UIColor+.swift */; };
 		3A2F483723DDB26A0034C429 /* QuestionViewController+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F483623DDB26A0034C429 /* QuestionViewController+Layout.swift */; };
 		3A2F483923E537010034C429 /* QuestionViewController+ClickMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F483823E537010034C429 /* QuestionViewController+ClickMotion.swift */; };
+		3A2F483D23E6DD9A0034C429 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F483C23E6DD9A0034C429 /* UIButton+.swift */; };
 		3AF6A9BE23C4A72400B588CE /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3AF6A9BD23C4A72400B588CE /* .swiftlint.yml */; };
 		3AF6A9C223C4AD0300B588CE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3AF6A9C123C4AD0300B588CE /* GoogleService-Info.plist */; };
 		4C002D7423D0B49E00A1AC91 /* YetdaIntegrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C002D7323D0B49E00A1AC91 /* YetdaIntegrator.swift */; };
@@ -44,6 +45,7 @@
 		3A2F483223DDB1EF0034C429 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = SOURCE_ROOT; };
 		3A2F483623DDB26A0034C429 /* QuestionViewController+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QuestionViewController+Layout.swift"; sourceTree = "<group>"; };
 		3A2F483823E537010034C429 /* QuestionViewController+ClickMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QuestionViewController+ClickMotion.swift"; sourceTree = "<group>"; };
+		3A2F483C23E6DD9A0034C429 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIButton+.swift"; path = "Yetda_iOS/Source/Extension/UIButton+.swift"; sourceTree = SOURCE_ROOT; };
 		3AF6A9BD23C4A72400B588CE /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		3AF6A9C123C4AD0300B588CE /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		4C002D7323D0B49E00A1AC91 /* YetdaIntegrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YetdaIntegrator.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 			children = (
 				3A2F483023DDB1C50034C429 /* UIView+.swift */,
 				3A2F483223DDB1EF0034C429 /* UIColor+.swift */,
+				3A2F483C23E6DD9A0034C429 /* UIButton+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<unknown>";
@@ -411,6 +414,7 @@
 				FAECF8B723DADF7200B5DF95 /* BirthDayViewController+layout.swift in Sources */,
 				FA36BF6523E27E2F00B9F1F5 /* GenderViewController+UIButton.swift in Sources */,
 				FA85C4C523E1595F0083C550 /* GenderViewController+layout.swift in Sources */,
+				3A2F483D23E6DD9A0034C429 /* UIButton+.swift in Sources */,
 				FAEC903723CC84A200010233 /* NameViewController.swift in Sources */,
 				3A2F483923E537010034C429 /* QuestionViewController+ClickMotion.swift in Sources */,
 				4C002D7B23D0B9C500A1AC91 /* BaseViewController.swift in Sources */,

--- a/Yetda_iOS/Source/Extension/UIButton+.swift
+++ b/Yetda_iOS/Source/Extension/UIButton+.swift
@@ -1,0 +1,27 @@
+//
+//  UIButton+.swift
+//  Yetda_iOS
+//
+//  Created by 임수현 on 2020/02/02.
+//  Copyright © 2020 Yetda. All rights reserved.
+//
+
+import UIKit
+
+extension UIButton {
+    func setNextButton(isEnable: Bool) {
+
+        self.isEnabled = isEnable
+        self.setTitle("다음", for: .normal)
+        self.titleLabel?.font = .systemFont(ofSize: 18)
+        self.layer.cornerRadius = 22
+        
+        if isEnable {
+            self.setTitleColor(.white, for: .normal)
+            self.backgroundColor = .pastelRed
+        } else {
+            self.setTitleColor(.veryLightPink, for: .normal)
+            self.backgroundColor = .veryLightPink2
+        }
+    }
+}

--- a/Yetda_iOS/Source/Extension/UIButton+.swift
+++ b/Yetda_iOS/Source/Extension/UIButton+.swift
@@ -15,8 +15,11 @@ extension UIButton {
         self.setTitle("다음", for: .normal)
         self.titleLabel?.font = .systemFont(ofSize: 18)
         self.layer.cornerRadius = 22
-        
-        if isEnable {
+        setNextButtonEnable(isEnabled)
+    }
+    
+    func setNextButtonEnable(_ enable: Bool){
+        if enable {
             self.setTitleColor(.white, for: .normal)
             self.backgroundColor = .pastelRed
         } else {

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+TextField.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+TextField.swift
@@ -10,51 +10,67 @@ import UIKit
 
 // MARK: - UITextFieldDelegate Extension
 extension NameViewController: UITextFieldDelegate {
-//    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-//        // return NO to disallow editing.
-//        print("TextField should begin editing method called")
-//        return true
-//    }
+    /*
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        // return NO to disallow editing.
+        print("TextField should begin editing method called")
+        return true
+    }
+     */
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
         // became first responder
-        bottomBorderView.backgroundColor = .darkGray
         print("TextField did begin editing method called")
     }
 
-//    func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-//        // return YES to allow editing to stop and to resign first responder status. NO to disallow the editing session to end
-//        print("TextField should snd editing method called")
-//        return false
-//    }
-
+    /*
+    func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        // return YES to allow editing to stop and to resign first responder status. NO to disallow the editing session to end
+        print("TextField should snd editing method called")
+        return false
+    }
+     */
+    
     func textFieldDidEndEditing(_ textField: UITextField) {
         // may be called if forced even if shouldEndEditing returns NO (e.g. view removed from window) or endEditing:YES called
         print("TextField did end editing method called")
         
     }
-//
-//    func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
-//        // if implemented, called in place of textFieldDidEndEditing:
-//        print("TextField did end editing with reason method called")
-//    }
+    
+    /*
+    func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
+        // if implemented, called in place of textFieldDidEndEditing:
+        print("TextField did end editing with reason method called")
+    }
 
-//    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-//        // return NO to not change text
-//        print("While entering the characters this method gets called")
-//        return true
-//    }
-//
-//    func textFieldShouldClear(_ textField: UITextField) -> Bool {
-//        // called when clear button pressed. return NO to ignore (no notifications)
-//        print("TextField should clear method called")
-//        return true
-//    }
-//
-//    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-//        // called when 'return' key pressed. return NO to ignore.
-//        print("TextField should return method called")
-//        // may be useful: textField.resignFirstResponder()
-//        return true
-//    }
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        // return NO to not change text
+        print("While entering the characters this method gets called")
+        return true
+    }
+
+    func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        // called when clear button pressed. return NO to ignore (no notifications)
+        print("TextField should clear method called")
+        return true
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        // called when 'return' key pressed. return NO to ignore.
+        print("TextField should return method called")
+        // may be useful: textField.resignFirstResponder()
+        return true
+    }
+     */
+    
+    // MARK: - Custom Code
+    @objc func textFieldDidChange(_ textField: UITextField) {
+        guard let text = textField.text else { return }
+        
+        if text.count > 0 {
+            nextButton.setNextButton(isEnable: true)
+        } else {
+            nextButton.setNextButton(isEnable: false)
+        }
+    }
 }

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+TextField.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+TextField.swift
@@ -73,4 +73,18 @@ extension NameViewController: UITextFieldDelegate {
             nextButton.setNextButton(isEnable: false)
         }
     }
+    
+    @objc func keyboardWillShow(_ notification: Notification) {
+        guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
+            else { return }
+        
+        let keybaordRectangle = keyboardFrame.cgRectValue
+        let keyboardHeight = keybaordRectangle.height
+        
+        nextButton.transform = CGAffineTransform(translationX: 0, y: -keyboardHeight)
+    }
+      
+    @objc func keyboardWillHide(_ notification: Notification) {
+        nextButton.transform = .identity
+    }
 }

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+TextField.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+TextField.swift
@@ -42,13 +42,20 @@ extension NameViewController: UITextFieldDelegate {
         // if implemented, called in place of textFieldDidEndEditing:
         print("TextField did end editing with reason method called")
     }
-
+     */
+    
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         // return NO to not change text
         print("While entering the characters this method gets called")
-        return true
+        
+        // 최대 글자 수 7
+        let currentText = textField.text ?? ""
+        guard let stringRange = Range(range, in: currentText) else { return false }
+        let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+        return updatedText.count <= 7
     }
-
+    
+    /*
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
         // called when clear button pressed. return NO to ignore (no notifications)
         print("TextField should clear method called")

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
@@ -48,30 +48,25 @@ extension NameViewController {
         }
         
         // add subviews
-        verticalStackView.addSubview(guideLabel)
-        verticalStackView.addSubview(nameTextField)
-        verticalStackView.addSubview(bottomBorderView)
+        self.view.addSubview(nameTextField)
+        self.view.addSubview(bottomBorderView)
         
         // setup subviews properties
-        setGuideLabel()
-        setNameTextField()
         setBottomBorderView()
     }
     
     func setGuideLabel() {
         
         // setup self view properties
-        guideLabel.numberOfLines = 0
-        guideLabel.text = """
-                        선물 줄 분의 이름이
-                        어떻게 되시나요?
-                        """
-        guideLabel.textColor = .darkGray
+        guideLabel.text = "선물을 받을 사람은?"
+        guideLabel.textColor = .brownishGrey
+        guideLabel.font = .systemFont(ofSize: 18)
+        guideLabel.sizeToFit()
         
         // Set SNP Constraints
         guideLabel.snp.makeConstraints { (make) in
-            make.trailing.equalTo(verticalStackView)
-            make.leading.equalTo(verticalStackView)
+            make.centerX.equalTo(self.view)
+            make.top.equalTo(self.view).offset(200)
         }
     }
     

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
@@ -24,10 +24,10 @@ extension NameViewController {
         
         // setup self view contraints
         nextButton.snp.makeConstraints { (make) in
-            make.centerX.equalTo(view)
+            make.centerX.equalTo(self.view)
             make.left.right.equalTo(self.view).inset(24)
+            make.bottom.equalTo(self.view).inset(50)
             make.height.equalTo(44)
-            make.bottom.equalTo(-80)
         }
     }
     

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
@@ -20,13 +20,13 @@ extension NameViewController {
     func setButton() {
         
         // setup self view properties
-        setupButton(button: nextButton)
+        nextButton.setNextButton(isEnable: true)
         
         // setup self view contraints
         nextButton.snp.makeConstraints { (make) in
             make.centerX.equalTo(view)
-            make.width.equalTo(240)
-            make.height.equalTo(36)
+            make.left.right.equalTo(self.view).inset(24)
+            make.height.equalTo(44)
             make.bottom.equalTo(-80)
         }
     }

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
@@ -20,7 +20,7 @@ extension NameViewController {
     func setButton() {
         
         // setup self view properties
-        nextButton.setNextButton(isEnable: true)
+        nextButton.setNextButton(isEnable: false)
         
         // setup self view contraints
         nextButton.snp.makeConstraints { (make) in
@@ -53,6 +53,7 @@ extension NameViewController {
         nameTextField.textAlignment = .center
         nameTextField.font = .boldSystemFont(ofSize: 34)
         nameTextField.delegate = self
+        nameTextField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
         
         // setup self view contraints
         nameTextField.snp.makeConstraints { (make) in

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
@@ -10,10 +10,19 @@ import UIKit
 
 extension NameViewController {
     
-    
+    /*
+     1. setup self view properties
+     2. setup self view contraints
+     3. add subviews
+     4. setup subviews properties
+    */
+
     func setButton() {
+        
+        // setup self view properties
         setupButton(button: nextButton)
         
+        // setup self view contraints
         nextButton.snp.makeConstraints { (make) in
             make.centerX.equalTo(view)
             make.width.equalTo(240)
@@ -23,30 +32,41 @@ extension NameViewController {
     }
     
     func setVerticalStackView() {
-        verticalStackView = UIStackView()
-        verticalStackView.axis = .vertical
-        verticalStackView.backgroundColor = .green
         
         view.addSubview(verticalStackView)
         
+        // setup self view properties
+        verticalStackView.axis = .vertical
+        verticalStackView.backgroundColor = .green
+        
+        // setup self view contraints
         verticalStackView.snp.makeConstraints { (make) in
-        make.trailing.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
-        make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(20)
-        make.bottom.equalTo(nextButton.snp_topMargin).offset(-20)
-        make.top.equalTo(200)
-            }
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
+            make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(20)
+            make.bottom.equalTo(nextButton.snp_topMargin).offset(-20)
+            make.top.equalTo(200)
+        }
+        
+        // add subviews
+        verticalStackView.addSubview(guideLabel)
+        verticalStackView.addSubview(nameTextField)
+        verticalStackView.addSubview(bottomBorderView)
+        
+        // setup subviews properties
+        setGuideLabel()
+        setNameTextField()
+        setBottomBorderView()
     }
     
     func setGuideLabel() {
-        guideLabel = UILabel()
+        
+        // setup self view properties
         guideLabel.numberOfLines = 0
         guideLabel.text = """
-        선물 줄 분의 이름이
-        어떻게 되시나요?
-        """
+                        선물 줄 분의 이름이
+                        어떻게 되시나요?
+                        """
         guideLabel.textColor = .darkGray
-        
-        verticalStackView.addSubview(guideLabel)
         
         // Set SNP Constraints
         guideLabel.snp.makeConstraints { (make) in
@@ -56,29 +76,30 @@ extension NameViewController {
     }
     
     func setNameTextField() {
-        nameTextField = UITextField()
+        
+        // setup self view properties
         nameTextField.borderStyle = .none
         nameTextField.placeholder = "이름"
         nameTextField.delegate = self
         
-        // CreateBottom Border with UIView
-        bottomBorderView = UIView()
+        // setup self view contraints
+        nameTextField.snp.makeConstraints { (make) in
+            make.topMargin.equalTo(guideLabel.snp_bottomMargin).offset(20)
+            make.trailing.equalTo(verticalStackView)
+            make.leading.equalTo(verticalStackView)
+        }
+    }
+    
+    func setBottomBorderView() {
+        
+        // setup self view properties
         if nameTextField.isSelected {
             bottomBorderView.backgroundColor = .darkGray
         } else {
             bottomBorderView.backgroundColor = .lightGray
         }
         
-        verticalStackView.addSubview(nameTextField)
-        verticalStackView.addSubview(bottomBorderView)
-        
-        nameTextField.snp.makeConstraints { (make) in
-            make.topMargin.equalTo(guideLabel.snp_bottomMargin).offset(20)
-            make.trailing.equalTo(verticalStackView)
-            make.leading.equalTo(verticalStackView)
-
-        }
-        
+        // setup self view contraints
         bottomBorderView.snp.makeConstraints { (make) in
             make.topMargin.equalTo(nameTextField.snp_bottomMargin).offset(20)
             make.trailing.equalTo(verticalStackView)
@@ -86,5 +107,4 @@ extension NameViewController {
             make.height.equalTo(2)
         }
     }
-    
 }

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
@@ -48,7 +48,6 @@ extension NameViewController {
         }
         
         // add subviews
-        self.view.addSubview(nameTextField)
         self.view.addSubview(bottomBorderView)
         
         // setup subviews properties
@@ -74,14 +73,15 @@ extension NameViewController {
         
         // setup self view properties
         nameTextField.borderStyle = .none
-        nameTextField.placeholder = "이름"
+        nameTextField.textAlignment = .center
         nameTextField.delegate = self
         
         // setup self view contraints
         nameTextField.snp.makeConstraints { (make) in
-            make.topMargin.equalTo(guideLabel.snp_bottomMargin).offset(20)
-            make.trailing.equalTo(verticalStackView)
-            make.leading.equalTo(verticalStackView)
+            make.top.equalTo(guideLabel).offset(40)
+            make.centerX.equalTo(self.view)
+            make.left.equalTo(self.view).offset(75)
+            make.right.equalTo(self.view).offset(-75)
         }
     }
     

--- a/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController+layout.swift
@@ -31,29 +31,6 @@ extension NameViewController {
         }
     }
     
-    func setVerticalStackView() {
-        
-        view.addSubview(verticalStackView)
-        
-        // setup self view properties
-        verticalStackView.axis = .vertical
-        verticalStackView.backgroundColor = .green
-        
-        // setup self view contraints
-        verticalStackView.snp.makeConstraints { (make) in
-            make.trailing.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
-            make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(20)
-            make.bottom.equalTo(nextButton.snp_topMargin).offset(-20)
-            make.top.equalTo(200)
-        }
-        
-        // add subviews
-        self.view.addSubview(bottomBorderView)
-        
-        // setup subviews properties
-        setBottomBorderView()
-    }
-    
     func setGuideLabel() {
         
         // setup self view properties
@@ -74,6 +51,7 @@ extension NameViewController {
         // setup self view properties
         nameTextField.borderStyle = .none
         nameTextField.textAlignment = .center
+        nameTextField.font = .boldSystemFont(ofSize: 34)
         nameTextField.delegate = self
         
         // setup self view contraints
@@ -88,17 +66,12 @@ extension NameViewController {
     func setBottomBorderView() {
         
         // setup self view properties
-        if nameTextField.isSelected {
-            bottomBorderView.backgroundColor = .darkGray
-        } else {
-            bottomBorderView.backgroundColor = .lightGray
-        }
+        bottomBorderView.backgroundColor = .blueGrey
         
         // setup self view contraints
         bottomBorderView.snp.makeConstraints { (make) in
-            make.topMargin.equalTo(nameTextField.snp_bottomMargin).offset(20)
-            make.trailing.equalTo(verticalStackView)
-            make.leading.equalTo(verticalStackView)
+            make.top.equalTo(nameTextField.snp.bottom)
+            make.left.right.equalTo(nameTextField)
             make.height.equalTo(2)
         }
     }

--- a/Yetda_iOS/Source/Views/NameView/NameViewController.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController.swift
@@ -12,10 +12,10 @@ import SnapKit
 class NameViewController: BaseViewController {
 
     @IBOutlet weak var nextButton: UIButton!
-    var guideLabel: UILabel!
-    var nameTextField: UITextField!
-    var verticalStackView: UIStackView!
-    var bottomBorderView: UIView!
+    var guideLabel: UILabel = UILabel()
+    var verticalStackView: UIStackView = UIStackView()
+    var nameTextField: UITextField = UITextField()
+    var bottomBorderView: UIView = UIView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,9 +35,6 @@ class NameViewController: BaseViewController {
         
         setButton()
         setVerticalStackView()
-        setGuideLabel()
-        setNameTextField()
-        
     }
     
     override func setupButton(button: UIButton) {
@@ -48,18 +45,5 @@ class NameViewController: BaseViewController {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
     }
-    
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
-
-
 }
 

--- a/Yetda_iOS/Source/Views/NameView/NameViewController.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController.swift
@@ -36,9 +36,11 @@ class NameViewController: BaseViewController {
         setButton()
         
         self.view.addSubview(guideLabel)
+        self.view.addSubview(nameTextField)
         
         setGuideLabel()
         setVerticalStackView()
+        setNameTextField()
     }
     
     override func setupButton(button: UIButton) {

--- a/Yetda_iOS/Source/Views/NameView/NameViewController.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController.swift
@@ -34,6 +34,10 @@ class NameViewController: BaseViewController {
         super.setupUI()
         
         setButton()
+        
+        self.view.addSubview(guideLabel)
+        
+        setGuideLabel()
         setVerticalStackView()
     }
     

--- a/Yetda_iOS/Source/Views/NameView/NameViewController.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController.swift
@@ -13,7 +13,6 @@ class NameViewController: BaseViewController {
 
     @IBOutlet weak var nextButton: UIButton!
     var guideLabel: UILabel = UILabel()
-    var verticalStackView: UIStackView = UIStackView()
     var nameTextField: UITextField = UITextField()
     var bottomBorderView: UIView = UIView()
     
@@ -37,10 +36,11 @@ class NameViewController: BaseViewController {
         
         self.view.addSubview(guideLabel)
         self.view.addSubview(nameTextField)
+        self.view.addSubview(bottomBorderView)
         
         setGuideLabel()
-        setVerticalStackView()
         setNameTextField()
+        setBottomBorderView()
     }
     
     override func setupButton(button: UIButton) {

--- a/Yetda_iOS/Source/Views/NameView/NameViewController.swift
+++ b/Yetda_iOS/Source/Views/NameView/NameViewController.swift
@@ -23,9 +23,17 @@ class NameViewController: BaseViewController {
         navigationController?.setNavigationBarHidden(false, animated: true)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        nameTextField.becomeFirstResponder()
+    }
+    
     // custom setup
     override func setup() {
         super.setup()
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     // MARK: - apply layout from extension
@@ -41,11 +49,6 @@ class NameViewController: BaseViewController {
         setGuideLabel()
         setNameTextField()
         setBottomBorderView()
-    }
-    
-    override func setupButton(button: UIButton) {
-        super.setupButton(button: nextButton)
-        button.setTitle("다음", for: .normal)
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
+++ b/Yetda_iOS/Source/Views/QuestionView/QuestionViewController+Layout.swift
@@ -31,7 +31,7 @@ extension QuestionViewController {
         
         descriptionLabel.text = "@@님은 어떤 사람인가요?"
         descriptionLabel.font = .systemFont(ofSize: 18)
-        descriptionLabel.textColor = UIColor.brownishGrey   
+        descriptionLabel.textColor = UIColor.brownishGrey
         descriptionLabel.sizeToFit()
         
         descriptionLabel.snp.makeConstraints { (make) in


### PR DESCRIPTION
resolve: #34 

## TODO
* 제플린에 iOS용 GUI 추가되면 디테일 사이즈 조정 필요
* 뒤로가기 버튼
* 상단의 진행률 프로그래스 바
* nextButton의 shadow 지정
* 최대 글자 수(7글자)를 초과할 경우 하단에 노티 -> 일정 보고 2차에 반영 예정

## DONE
* 각 컴포넌트 위치 및 색상 조정
* 화면 진입 시 textField에 포커싱 & 키보드 등장
* 키보드 등장 시 nextButton의 위치가 키보드 위로, 키보드가 내려가면 따라서 아래로 이동
* textField의 최대 글자 수 7글자 이하로 제한

![nameViewControllerGUI](https://user-images.githubusercontent.com/37800715/73613673-646b7480-463b-11ea-93ce-d31b17c4c40e.gif)
